### PR TITLE
Fix overlapping quest header

### DIFF
--- a/Interface/AddOns/AltzUI/mods/tweaks/watchframe.lua
+++ b/Interface/AddOns/AltzUI/mods/tweaks/watchframe.lua
@@ -43,6 +43,7 @@ hooksecurefunc(QUEST_TRACKER_MODULE, "SetBlockHeader", function(_, block)
     block.HeaderText:SetTextColor(G.Ccolor.r, G.Ccolor.g, G.Ccolor.b)
     block.HeaderText:SetJustifyH("LEFT")
     block.HeaderText:SetWidth(200)
+    block.HeaderText:SetHeight(15)
 	local heightcheck = block.HeaderText:GetNumLines()      
     if heightcheck==2 then
         local height = block:GetHeight()     


### PR DESCRIPTION
The second quest in the quest tracker objective always ends up underneath the first quest. This pull request fixes that.

I have posted in wow interface in the comments section with a screenshot: http://www.wowinterface.com/downloads/info21263-AltzUIforLegion.html#comments