### PR TITLE
Guild bank safety checks

### DIFF
--- a/Interface/AddOns/AltzUI/mods/tweaks/watchframe.lua
+++ b/Interface/AddOns/AltzUI/mods/tweaks/watchframe.lua
@@ -43,6 +43,7 @@ hooksecurefunc(QUEST_TRACKER_MODULE, "SetBlockHeader", function(_, block)
     block.HeaderText:SetTextColor(G.Ccolor.r, G.Ccolor.g, G.Ccolor.b)
     block.HeaderText:SetJustifyH("LEFT")
     block.HeaderText:SetWidth(200)
+    block.HeaderText:SetHeight(15)
 	local heightcheck = block.HeaderText:GetNumLines()      
     if heightcheck==2 then
         local height = block:GetHeight()     

--- a/Interface/AddOns/AltzUI/mods/tweaks/watchframe.lua
+++ b/Interface/AddOns/AltzUI/mods/tweaks/watchframe.lua
@@ -44,7 +44,7 @@ hooksecurefunc(QUEST_TRACKER_MODULE, "SetBlockHeader", function(_, block)
     block.HeaderText:SetJustifyH("LEFT")
     block.HeaderText:SetWidth(200)
     block.HeaderText:SetHeight(15)
-	local heightcheck = block.HeaderText:GetNumLines()
+    local heightcheck = block.HeaderText:GetNumLines()
     if heightcheck==2 then
         local height = block:GetHeight()     
         block:SetHeight(height + 2)

--- a/Interface/AddOns/Aurora/AddOns/Blizzard_GuildBankUI.lua
+++ b/Interface/AddOns/Aurora/AddOns/Blizzard_GuildBankUI.lua
@@ -14,13 +14,21 @@ C.themes["Blizzard_GuildBankUI"] = function()
 	GuildBankTabLimitBackgroundLeft:SetTexture("")
 	GuildBankTabLimitBackgroundRight:SetTexture("")
 	GuildBankEmblemFrame:Hide()
-	GuildBankPopupFrameTopLeft:Hide()
-	GuildBankPopupFrameBottomLeft:Hide()
+	if GuildBankPopupFrameTopLeft then
+		GuildBankPopupFrameTopLeft:Hide()
+	end
+	if GuildBankPopupFrameBottomLeft then
+		GuildBankPopupFrameBottomLeft:Hide()
+	end
 	GuildBankMoneyFrameBackgroundLeft:Hide()
 	GuildBankMoneyFrameBackgroundMiddle:Hide()
 	GuildBankMoneyFrameBackgroundRight:Hide()
-	select(2, GuildBankPopupFrame:GetRegions()):Hide()
-	select(4, GuildBankPopupFrame:GetRegions()):Hide()
+	if select(2, GuildBankPopupFrame:GetRegions()) then
+		select(2, GuildBankPopupFrame:GetRegions()):Hide()
+	end
+	if select(4, GuildBankPopupFrame:GetRegions()) then
+		select(4, GuildBankPopupFrame:GetRegions()):Hide()
+	end
 	GuildBankPopupNameLeft:Hide()
 	GuildBankPopupNameMiddle:Hide()
 	GuildBankPopupNameRight:Hide()
@@ -107,11 +115,14 @@ C.themes["Blizzard_GuildBankUI"] = function()
 
 	for i = 1, NUM_GUILDBANK_ICONS_PER_ROW * NUM_GUILDBANK_ICON_ROWS do
 		local bu = _G["GuildBankPopupButton"..i]
+		if bu then
+			bu:SetCheckedTexture(C.media.checked)
+			select(2, bu:GetRegions()):Hide()
+		end
 
-		bu:SetCheckedTexture(C.media.checked)
-		select(2, bu:GetRegions()):Hide()
-
-		_G["GuildBankPopupButton"..i.."Icon"]:SetTexCoord(.08, .92, .08, .92)
+		if _G["GuildBankPopupButton"..i.."Icon"] then
+			_G["GuildBankPopupButton"..i.."Icon"]:SetTexCoord(.08, .92, .08, .92)
+		end
 
 		F.CreateBG(_G["GuildBankPopupButton"..i.."Icon"])
 	end

--- a/Interface/AddOns/Aurora/aurora.lua
+++ b/Interface/AddOns/Aurora/aurora.lua
@@ -96,15 +96,19 @@ end
 
 F.CreateBG = function(frame)
 	local f = frame
-	if frame:GetObjectType() == "Texture" then f = frame:GetParent() end
+	if f then
+		if frame:GetObjectType() == "Texture" then f = frame:GetParent() end
 
-	local bg = f:CreateTexture(nil, "BACKGROUND")
-	bg:SetPoint("TOPLEFT", frame, -1, 1)
-	bg:SetPoint("BOTTOMRIGHT", frame, 1, -1)
-	bg:SetTexture(C.media.backdrop)
-	bg:SetVertexColor(0, 0, 0)
+		local bg = f:CreateTexture(nil, "BACKGROUND")
+		bg:SetPoint("TOPLEFT", frame, -1, 1)
+		bg:SetPoint("BOTTOMRIGHT", frame, 1, -1)
+		bg:SetTexture(C.media.backdrop)
+		bg:SetVertexColor(0, 0, 0)
 
-	return bg
+		return bg
+	else
+		return frame
+	end
 end
 
 -- we assign these after loading variables for caching


### PR DESCRIPTION
Seems broken right now. These changes fixes it for me. However, I'm unsure how you want to handle Aurora/aurora.lua line:99-110

If f/frame is nil, then the entire block throws an error. It returns bg, but when it's nil, I made it return the frame nil value instead of bg.