### PR TITLE
二個修改

### DIFF
--- a/Interface/AddOns/AltzUI/mods/bag/itemlevel.lua
+++ b/Interface/AddOns/AltzUI/mods/bag/itemlevel.lua
@@ -143,7 +143,7 @@ local function GetUpgradeID(itemString)
 	--local instaid,upgradeid =itemString:match("item:%d+:%d+:%d+:%d+:%d+:%d+:%-?%d+:%-?%d+:%d+:(%d+):%d:%d:(%d)")
 	--local instaid,upgradeid =itemString:match("item:%d+:%d+:%d+:%d+:%d+:%d+:%-?%d+:%-?%d+:%d+:%d+:(%d+):%d+:%d+:(%d+)")
 	if itemString then
-		local itemString = itemString:match("item[%-?%d:]+") or ""-- Standardize itemlink to itemstring
+		local itemString = itemString:match("itemLink[%-?%d:]+") or ""-- Standardize itemlink to itemstring
 		local instaid, _, numBonuses, affixes = select(12, strsplit(":", itemString, 15))
 		instaid=tonumber(instaid) or 7
 		if instaid >0 and (instaid-4)%8==0 then

--- a/Interface/AddOns/AltzUI/mods/panels/panels.lua
+++ b/Interface/AddOns/AltzUI/mods/panels/panels.lua
@@ -1520,6 +1520,9 @@ OrderHall_eframe:SetScript("OnEvent", function(self, event, arg1)
 				OrderHallCommandBar.Currency:SetFont(G.norFont, 14, "OUTLINE")
 				OrderHallCommandBar.Currency:SetTextColor(1, 1, 1)
 				OrderHallCommandBar.Currency:SetShadowOffset(0, 0)
+				
+				OrderHallCommandBar.CurrencyHitTest:ClearAllPoints()
+				OrderHallCommandBar.CurrencyHitTest:SetAllPoints(OrderHallCommandBar.CurrencyIcon)
 								
 				OrderHallCommandBar.WorldMapButton:Hide()
 				


### PR DESCRIPTION
1.嘗試修復部份用戶開啟物品等級顯示後會卡藍條和凍結的問題

2.給職業大廳tooltip更好的錨點(舊pr重推)