### PR TITLE
Fix error in API call to remove error when clicking on durability panel.

### DIFF
--- a/Interface/AddOns/AltzUI/mods/panels/panels.lua
+++ b/Interface/AddOns/AltzUI/mods/panels/panels.lua
@@ -1005,7 +1005,7 @@ local function UpdateEquipSetsList()
 	if count > 0 then
 		EquipSetsList = {}
 		for index = 1, count do 
-			local name, Icon, setID, isEquipped, totalItems, equippedItems, inventoryItems, missingItems, ignoredSlots = GetEquipmentSetInfo(index)
+			local name, Icon, setID, isEquipped, totalItems, equippedItems, inventoryItems, missingItems, ignoredSlots = C_EquipmentSet.GetEquipmentSetInfo(index)
 			EquipSetsList[index] = {
 				text = name,
 				icon = Icon,


### PR DESCRIPTION
This fixes the API call for the Durability panel which was using a removed GetEquipmentSetInfo API instead of the new C_EquipmentSet.GetEquipmentSetInfo.