### PR TITLE
Fix issue with using a removed API 

### DIFF
--- a/Interface/AddOns/AltzUI/mods/panels/panels.lua
+++ b/Interface/AddOns/AltzUI/mods/panels/panels.lua
@@ -1005,7 +1005,7 @@ local function UpdateEquipSetsList()
 	if count > 0 then
 		EquipSetsList = {}
 		for index = 1, count do 
-			local name, Icon, setID, isEquipped, totalItems, equippedItems, inventoryItems, missingItems, ignoredSlots = GetEquipmentSetInfo(index)
+			local name, Icon, setID, isEquipped, totalItems, equippedItems, inventoryItems, missingItems, ignoredSlots = C_EquipmentSet.GetEquipmentSetInfo(index)
 			EquipSetsList[index] = {
 				text = name,
 				icon = Icon,


### PR DESCRIPTION
This fixes the issue of the Durability Panel using an old removed API call, it updates the API call to use the new C_EquipmentSet table.