### PR TITLE
Init aCoreCDB.CooldownAura.Debuffs_Black on import

### DIFF
--- a/Interface/AddOns/AltzUIConfig/db.lua
+++ b/Interface/AddOns/AltzUIConfig/db.lua
@@ -1813,6 +1813,7 @@ T.ImportSettings = function(str)
 				aCoreCDB.CooldownAura = {}
 				aCoreCDB.CooldownAura.Buffs = {}
 				aCoreCDB.CooldownAura.Debuffs = {}
+				aCoreCDB.CooldownAura.Debuffs_Black = {}
 			end
 			
 			if sameclass then


### PR DESCRIPTION
Importing an export is currently broken. This fixes it for me.